### PR TITLE
db-uhttp: Add support for HTTP Delete method

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -232,6 +232,8 @@ pub enum Method {
     Put,
     /// PATCH Method.
     Patch,
+    /// Delete Method.
+    Delete,
 }
 
 impl Method {
@@ -247,6 +249,7 @@ impl Method {
             b"GET" => Ok(Self::Get),
             b"PUT" => Ok(Self::Put),
             b"PATCH" => Ok(Self::Patch),
+            b"DELETE" => Ok(Self::Delete),
             _ => Err(RequestError::InvalidHttpMethod("Unsupported HTTP method.")),
         }
     }
@@ -257,6 +260,7 @@ impl Method {
             Self::Get => b"GET",
             Self::Put => b"PUT",
             Self::Patch => b"PATCH",
+            Self::Delete => b"DELETE",
         }
     }
 
@@ -266,6 +270,7 @@ impl Method {
             Method::Get => "GET",
             Method::Put => "PUT",
             Method::Patch => "PATCH",
+            Method::Delete => "DELETE",
         }
     }
 }
@@ -369,11 +374,13 @@ mod tests {
         assert_eq!(Method::Get.raw(), b"GET");
         assert_eq!(Method::Put.raw(), b"PUT");
         assert_eq!(Method::Patch.raw(), b"PATCH");
+        assert_eq!(Method::Delete.raw(), b"DELETE");
 
         // Tests for try_from
         assert_eq!(Method::try_from(b"GET").unwrap(), Method::Get);
         assert_eq!(Method::try_from(b"PUT").unwrap(), Method::Put);
         assert_eq!(Method::try_from(b"PATCH").unwrap(), Method::Patch);
+        assert_eq!(Method::try_from(b"DELETE").unwrap(), Method::Delete);
         assert_eq!(
             Method::try_from(b"POST").unwrap_err(),
             RequestError::InvalidHttpMethod("Unsupported HTTP method.")
@@ -558,5 +565,8 @@ mod tests {
 
         let val = Method::Patch;
         assert_eq!(val.to_str(), "PATCH");
+
+        let val = Method::Delete;
+        assert_eq!(val.to_str(), "DELETE");
     }
 }


### PR DESCRIPTION
Add support for Method::Delete, which is needed for device hot-removal.
Also fix a clippy warning.

Fixes: https://github.com/firecracker-microvm/micro-http/issues/12

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>

## Reason for This PR

`[Author TODO: add issue # or explain reasoning.]`

## Description of Changes

`[Author TODO: add description of changes.]`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any newly added `unsafe` code is properly documented.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
