### PR TITLE
fix: hang on payload exceed 1k

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -552,6 +552,11 @@ impl<T: Read + Write + ScmSocket> HttpConnection<T> {
         self.parsed_requests.pop_front()
     }
 
+    /// Returns if parsed_requests is empty
+    pub fn has_parsed_requests(&self) -> bool {
+        !self.parsed_requests.is_empty()
+    }
+
     /// Returns `true` if there are bytes waiting to be written into the stream.
     pub fn pending_write(&self) -> bool {
         self.response_buffer.is_some() || !self.response_queue.is_empty()

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -552,7 +552,7 @@ impl<T: Read + Write + ScmSocket> HttpConnection<T> {
         self.parsed_requests.pop_front()
     }
 
-    /// Returns if parsed_requests is empty
+    /// Returns if parsed_requests is not empty
     pub fn has_parsed_requests(&self) -> bool {
         !self.parsed_requests.is_empty()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -621,6 +621,9 @@ impl HttpServer {
                     Ok(())
                 })
             {
+                if e.kind() == ErrorKind::Interrupted {
+                    continue;
+                }
                 if e.kind() == ErrorKind::WouldBlock {
                     break;
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -345,7 +345,7 @@ impl HttpServer {
     fn poll_events(&mut self, events: &mut mio::Events) -> Result<()> {
         loop {
             if let Err(e) = self.poll.poll(events, None) {
-                if e.kind() == ErrorKind::Interrupted {
+                if e.kind() == ErrorKind::Interrupted || e.kind() == ErrorKind::WouldBlock {
                     continue;
                 }
                 return Err(ServerError::IOError(e));


### PR DESCRIPTION

## Reason for This PR

the reason for hang on payload is because we changed epoll to mio
that only support edge trigger mode, we used to rely on level trigger
to make sure we not miss some event, but for edge trigger, we must make
sure we handle the event properly


## Description of Changes

change the way to handle accept and read event

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any newly added `unsafe` code is properly documented.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
